### PR TITLE
CMake support to enable compilation under Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 bazel-*
 .bazelrc
+build
+.vs
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+cmake_minimum_required(VERSION 3.1.0)
+project(astc-codec)
+
+option(OPTION_ASTC_TESTS "Build all the unit tests." ON)
+
+# TODO add support for the fuzzer, it has some additional dependencies we are not
+# yet bringing in.
+option(OPTION_BUILD_FUZZER "Build the fuzzer tests." OFF)
+
+set (CMAKE_CXX_STANDARD 11)
+if(OPTION_ASTC_TESTS)
+  enable_testing()
+
+  # No need to build gmock if an external project defines it.
+  if(NOT TARGET gmock_main)
+    # We use the approach suggested by https://crascit.com/2015/07/25/cmake-gtest/ to download gtest.
+    include(ExternalProject)
+    # Download and unpack googletest at configure time
+    configure_file(GoogleTest-CMakeLists.txt.in googletest-download/CMakeLists.txt)
+    execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download")
+    execute_process(COMMAND "${CMAKE_COMMAND}" --build . WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download")
+
+    # Prevent GoogleTest from overriding our compiler/linker options when building with Visual Studio
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+    # Add googletest directly to our build. This adds the following targets: gtest, gtest_main, gmock and gmock_main
+    add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src" "${CMAKE_BINARY_DIR}/googletest-build")
+  endif()
+endif()
+
+add_subdirectory(src/base)
+add_subdirectory(src/decoder)

--- a/GoogleTest-CMakeLists.txt.in
+++ b/GoogleTest-CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG "release-1.8.1"
+    SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    TEST_COMMAND ""
+)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ bool result = astc_codec::ASTCDecompressToRGBA(
 
 ## Building
 
+### With bazel
+
 Install [Bazel](https://bazel.build/), and then run:
 
 ```
@@ -32,11 +34,30 @@ bazel build :astc_codec -c opt
 
 astc-codec has been tested on Mac and Linux.
 
-## Run Tests
+### Run Tests
 
 ```
 bazel test //...
 ```
+
+### With CMake
+
+Install [CMake](https://https://cmake.org/), and the run:
+
+```
+mkdir build && cd build && cmake .. && make
+```
+
+Or open the project in your favorite IDE and import CMakeLists.txt.
+
+### Run Tests
+
+In the build directory, execute:
+
+```
+ctest
+```
+
 
 ## Contributing
 

--- a/cmake-format.json
+++ b/cmake-format.json
@@ -1,0 +1,38 @@
+{
+  "line_width": 120,
+  "dangle_parens": false,
+  "first_comment_is_literal": true,
+  "algorithm_order": [
+    0,
+    1,
+    2,
+    3
+  ],
+  "command_case": "lower",
+  "additional_commands": {
+    "foo": {
+      "flags": [
+        "BAR",
+        "BAZ"
+      ],
+      "kwargs": {
+        "HEADERS": "*",
+        "DEPENDS": "*",
+        "SOURCES": "*"
+      }
+    }
+  },
+  "separate_fn_name_with_space": false,
+  "always_wrap": [],
+  "separate_ctrl_name_with_space": false,
+  "max_subargs_per_line": 5,
+  "fence_pattern": "^\\s*([`~]{3}[`~]*)(.*)$",
+  "enable_markup": true,
+  "ruler_pattern": "^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$",
+  "tab_size": 2,
+  "keyword_case": "unchanged",
+  "enum_char": ".",
+  "literal_comment_pattern": null,
+  "bullet_char": "*",
+  "line_ending": "unix"
+}

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License Version 2.0 (the License); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing software distributed
+# under the License is distributed on an AS IS BASIS WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+add_library(base INTERFACE)
+target_include_directories(base INTERFACE ../..)
+
+if(OPTION_ASTC_TESTS)
+  add_executable(base_test
+                 test/bit_stream_test.cpp
+                 test/bottom_n_test.cpp
+                 test/math_utils_test.cpp
+                 test/optional_test.cpp
+                 test/string_utils_test.cpp
+                 test/type_traits_test.cpp
+                 test/uint128_test.cpp)
+  target_link_libraries(base_test base gmock_main)
+  add_test(base_test base_test)
+endif()

--- a/src/base/test/bottom_n_test.cpp
+++ b/src/base/test/bottom_n_test.cpp
@@ -33,7 +33,8 @@ TEST(BottomN, Sort) {
   {
     BottomN<int> heap(10);
     EXPECT_TRUE(heap.Empty());
-    pushAll(heap, (int[]){1, 2});
+    int list[] = { 1,2 };
+    pushAll(heap, list);
 
     EXPECT_EQ(heap.Size(), 2);
     EXPECT_FALSE(heap.Empty());
@@ -42,7 +43,8 @@ TEST(BottomN, Sort) {
 
   {
     BottomN<int> heap(6);
-    pushAll(heap, (int[]){1, 4, 3, 2, 2, 1});
+    int list[] = {1, 4, 3, 2, 2, 1};
+    pushAll(heap, list);
 
     EXPECT_EQ(heap.Size(), 6);
     EXPECT_THAT(heap.Pop(), ElementsAre(1, 1, 2, 2, 3, 4));
@@ -52,7 +54,8 @@ TEST(BottomN, Sort) {
 TEST(BottomN, Bounds) {
   {
     BottomN<int> heap(4);
-    pushAll(heap, (int[]){1, 2, 3, 4});
+    int list[] = { 1, 2, 3, 4 };
+    pushAll(heap, list);
     EXPECT_EQ(heap.Size(), 4);
 
     heap.Push(0);
@@ -63,21 +66,12 @@ TEST(BottomN, Bounds) {
 
   {
     BottomN<int> heap(4);
-    pushAll(heap, (int[]){4, 3, 2, 1});
+    int list[] = { 4, 3, 2,1 };
+    pushAll(heap, list);
     EXPECT_EQ(heap.Size(), 4);
 
-    pushAll(heap, (int[]){4, 4, 4, 4});
-    EXPECT_EQ(heap.Size(), 4);
-
-    EXPECT_THAT(heap.Pop(), ElementsAre(1, 2, 3, 4));
-  }
-
-  {
-    BottomN<int> heap(4);
-    pushAll(heap, (int[]){4, 3, 2, 1});
-    EXPECT_EQ(heap.Size(), 4);
-
-    pushAll(heap, (int[]){5, 5, 5, 5});
+    int list2[] = { 4,4,4,4 };
+    pushAll(heap, list2);
     EXPECT_EQ(heap.Size(), 4);
 
     EXPECT_THAT(heap.Pop(), ElementsAre(1, 2, 3, 4));
@@ -85,10 +79,25 @@ TEST(BottomN, Bounds) {
 
   {
     BottomN<int> heap(4);
-    pushAll(heap, (int[]){4, 3, 2, 1});
+    int list[] = { 4, 3, 2, 1 };
+    pushAll(heap, list);
     EXPECT_EQ(heap.Size(), 4);
 
-    pushAll(heap, (int[]){0, 0, 0, 0});
+    int list2[] = { 5, 5, 5, 5 };
+    pushAll(heap, list2);
+    EXPECT_EQ(heap.Size(), 4);
+
+    EXPECT_THAT(heap.Pop(), ElementsAre(1, 2, 3, 4));
+  }
+
+  {
+    BottomN<int> heap(4);
+    int list[] = { 4, 3, 2, 1 };
+    pushAll(heap, list);
+    EXPECT_EQ(heap.Size(), 4);
+
+    int list2[] = { 0, 0, 0, 0 };
+    pushAll(heap, list2);
     EXPECT_EQ(heap.Size(), 4);
 
     EXPECT_THAT(heap.Pop(), ElementsAre(0, 0, 0, 0));

--- a/src/base/test/type_traits_test.cpp
+++ b/src/base/test/type_traits_test.cpp
@@ -105,6 +105,7 @@ TEST(TypeTraits, IsTemplateInstantiation) {
       "nested std::vector<> is an instance of vector");
 }
 
+#ifndef _MSC_VER
 TEST(TypeTraits, IsRange) {
   static_assert(is_range<std::vector<int>>::value,
                 "vector<> should be detected as a range");
@@ -123,6 +124,7 @@ TEST(TypeTraits, IsRange) {
   static_assert(!is_range<const int*>::value,
                 "even const int* shouldn't be a range");
 }
+#endif
 
 }  // namespace base
 }  // namespace astc_codec

--- a/src/decoder/CMakeLists.txt
+++ b/src/decoder/CMakeLists.txt
@@ -1,0 +1,95 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+add_library(footprint footprint.cc)
+target_link_libraries(footprint base)
+
+add_library(astc_utils
+            astc_file.cc
+            endpoint_codec.cc
+            integer_sequence_codec.cc
+            intermediate_astc_block.cc
+            logical_astc_block.cc
+            partition.cc
+            physical_astc_block.cc
+            quantization.cc
+            weight_infill.cc)
+target_link_libraries(astc_utils PRIVATE base footprint)
+target_include_directories(astc_utils PRIVATE ../..)
+
+add_library(astc-codec codec.cc)
+target_link_libraries(astc-codec PRIVATE astc_utils)
+target_include_directories(astc-codec PUBLIC ../../include)
+target_include_directories(astc-codec PRIVATE ../..)
+
+add_executable(astc_inspector_cli tools/astc_inspector_cli.cc)
+target_include_directories(astc_inspector_cli PRIVATE ../..)
+target_link_libraries(astc_inspector_cli PRIVATE astc_utils)
+
+#
+# Testing
+#
+if(OPTION_ASTC_TESTS)
+  # Note that we will execute all the tests in the project directory.
+  # We do this to ensure the unit tests can pick up the required test data
+
+  # Create interface library exposing the root as an include directory
+  add_library(codec_test_dependencies INTERFACE)
+  target_include_directories(codec_test_dependencies INTERFACE ../..)
+
+  add_executable(physical_astc_block_test test/physical_astc_block_test.cc)
+  add_test(NAME physical_astc_block_test COMMAND physical_astc_block_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  target_link_libraries(physical_astc_block_test astc_utils codec_test_dependencies gmock_main)
+
+  add_executable(partition_test test/partition_test.cc)
+  add_test(NAME partition_test COMMAND partition_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  target_link_libraries(partition_test PRIVATE astc_utils codec_test_dependencies gmock_main)
+
+  add_executable(integer_sequence_codec_test test/integer_sequence_codec_test.cc)
+  target_link_libraries(integer_sequence_codec_test PRIVATE astc_utils codec_test_dependencies gmock_main)
+
+  add_executable(intermediate_astc_block_test test/intermediate_astc_block_test.cc)
+  add_test(NAME intermediate_astc_block_test COMMAND intermediate_astc_block_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  target_link_libraries(intermediate_astc_block_test PRIVATE astc_utils codec_test_dependencies gmock_main)
+
+  add_executable(quantization_test test/quantization_test.cc)
+  add_test(NAME quantization_test COMMAND quantization_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  target_link_libraries(quantization_test PRIVATE astc_utils codec_test_dependencies gmock_main)
+
+  add_executable(weight_infill_test test/weight_infill_test.cc)
+  add_test(NAME weight_infill_test COMMAND weight_infill_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  target_link_libraries(weight_infill_test PRIVATE astc_utils footprint codec_test_dependencies gmock_main)
+
+  add_executable(endpoint_codec_test test/endpoint_codec_test.cc)
+  add_test(NAME endpoint_codec_test COMMAND endpoint_codec_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  target_link_libraries(endpoint_codec_test PRIVATE astc_utils codec_test_dependencies gmock_main)
+
+  add_executable(logical_astc_block_test test/logical_astc_block_test.cc)
+  add_test(NAME logical_astc_block_test COMMAND logical_astc_block_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  target_link_libraries(logical_astc_block_test PRIVATE astc_utils codec_test_dependencies gmock_main)
+
+  add_executable(codec_test test/codec_test.cc)
+  add_test(NAME codec_test COMMAND codec_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+  target_link_libraries(codec_test PRIVATE astc-codec codec_test_dependencies gmock_main)
+
+  add_executable(footprint_test test/footprint_test.cc)
+  add_test(NAME footprint_test COMMAND footprint_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  target_link_libraries(footprint_test PRIVATE footprint codec_test_dependencies gmock_main)
+
+  if(OPTION_BUILD_FUZZER)
+    message(FATAL_ERROR "Not yet supported due to missing dependencies")
+    add_executable(astc_fuzzer test/astc_fuzzer.cc codec_test_dependencies gmock_main)
+    target_link_libraries(astc_fuzzer PRIVATE astc-codec honggfuzz benchmark)
+  endif()
+endif()

--- a/src/decoder/integer_sequence_codec.cc
+++ b/src/decoder/integer_sequence_codec.cc
@@ -193,13 +193,20 @@ inline constexpr bool IsPow2(T x) { return (x & (x - 1)) == 0; }
 const int kInterleavedQuintBits[3] = { 3, 2, 2 };
 const int kInterleavedTritBits[5] = { 2, 2, 1, 2, 1 };
 
+// Some template meta programming to get around the fact that MSVC
+// will not allow  (ValRange == 5) ? 3 : 5 as a template parameter
+template<int ValRange>
+struct DecodeBlockSize {
+  enum { value =  (ValRange == 5 ? 3 : 5) };
+};
+
 // Decodes either a trit or quint block using the BISE (Bounded Integer Sequence
 // Encoding) defined in Section C.2.12 of the ASTC specification. ValRange is
 // expected to be either 3 or 5 depending on whether or not we're encoding trits
 // or quints respectively. In other words, it is the remaining factor in whether
 // the passed blocks contain encoded values of the form 3*2^k or 5*2^k.
 template<int ValRange>
-std::array<int, /* kNumVals = */ (ValRange == 5) ? 3 : 5> DecodeISEBlock(
+std::array<int, /* kNumVals = */ DecodeBlockSize<ValRange>::value> DecodeISEBlock(
     uint64_t block_bits, int num_bits) {
   static_assert(ValRange == 3 || ValRange == 5,
                 "We only know about trits and quints");


### PR DESCRIPTION
- Add support for cmake
- Template fix to enable compilation with visual studio.
- Exclusion of static type tests under visual studio
- Fix unit tests due to declaration issues

Note we do not build the fuzzing target.

Test: All unit tests green on VS2017, MacOs, Linux

Change-Id: Ie8437f61d187fff03279c99fde0ff565e8f39b50