### PR TITLE
Sync/format build files

### DIFF
--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+licenses(["notice"])
+
 cc_library(
     name = "base",
     hdrs = [
@@ -24,6 +26,7 @@ cc_library(
         "uint128.h",
         "utils.h",
     ],
+    features = ["-parse_headers"],
     visibility = ["//src/decoder:__pkg__"],
 )
 

--- a/src/decoder/BUILD.bazel
+++ b/src/decoder/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+licenses(["notice"])
+
 cc_library(
     name = "footprint",
     srcs = ["footprint.cc"],
@@ -47,6 +49,10 @@ cc_library(
         "types.h",
         "weight_infill.h",
     ],
+    copts = [
+        "-Wno-unused-variable",
+        "-O3",
+    ],
     deps = [
         ":footprint",
         "//src/base",
@@ -57,12 +63,12 @@ cc_library(
     name = "codec",
     srcs = ["codec.cc"],
     hdrs = ["codec.h"],
+    visibility = ["//:__pkg__"],
     deps = [
         ":astc_utils",
         ":footprint",
         "//src/base",
     ],
-    visibility = ["//:__pkg__"],
 )
 
 cc_binary(
@@ -82,10 +88,9 @@ cc_binary(
 
 cc_library(
     name = "test",
+    testonly = 1,
     hdrs = ["test/image_utils.h"],
-    deps = [
-        "@gtest//:gtest_main",
-    ],
+    deps = ["@gtest//:gtest_main"],
 )
 
 cc_test(
@@ -95,12 +100,13 @@ cc_test(
     deps = [
         ":astc_utils",
         "@gtest//:gtest_main",
+        "//src/base",
     ],
 )
 
 cc_test(
     name = "partition_test",
-    size = "small",
+    size = "medium",
     srcs = ["test/partition_test.cc"],
     deps = [
         ":astc_utils",
@@ -115,6 +121,7 @@ cc_test(
     deps = [
         ":astc_utils",
         "@gtest//:gtest_main",
+        "//src/base",
     ],
 )
 
@@ -180,8 +187,8 @@ cc_test(
         "testdata/rgb_*.bmp",
     ]),
     deps = [
-        ":test",
         ":astc_utils",
+        ":test",
         "@gtest//:gtest_main",
     ],
 )
@@ -195,9 +202,10 @@ cc_test(
         "testdata/atlas_small_*.bmp",
     ]),
     deps = [
-        ":test",
         ":codec",
+        ":test",
         "@gtest//:gtest_main",
+        "//:api",
     ],
 )
 

--- a/src/decoder/partition.cc
+++ b/src/decoder/partition.cc
@@ -169,7 +169,7 @@ struct PartitionHasher {
 
     // The return value will be the hash of the assignment according to this
     // mapping
-    const auto seed = 0;
+    const size_t seed = 0;
     return std::accumulate(part.assignment.begin(), part.assignment.end(), seed,
                            [&mapping](size_t seed, const int& subset) {
                              std::hash<size_t> hasher;


### PR DESCRIPTION
* Always compile astc_utils with -O3, since it is very slow when built
  with fastbuild.
* Add missing licenses() declarations.
* Declare test library as testonly.
* Run BUILD file formatter.

Additionally, fix one ambiguous usage of auto in src/decoder/parition.cc