### PR TITLE
Fixed repeated variable name in README.md’s sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const size_t height = 480;
 std::vector<uint8_t> result;
 result.resize(width * height * 4);
 
-bool result = astc_codec::ASTCDecompressToRGBA(
+bool success = astc_codec::ASTCDecompressToRGBA(
     astc.data(), astc.size(), width, height, astc_codec::FootprintType::k4x4,
     result.data(), result.size(), /* stride */ width * 4);
 ```


### PR DESCRIPTION
… Both the output `std::vector<uint8_t>` and the success/fail `bool` were named `result` – which that wouldn’t work. How about `bool success`?